### PR TITLE
fix: remove deprecated warning on PHP 8.1

### DIFF
--- a/src/Camcima/Soap/Client.php
+++ b/src/Camcima/Soap/Client.php
@@ -218,6 +218,7 @@ class Client extends \SoapClient
     /**
      * {@inheritDoc}
      */
+    #[ReturnTypeWillChange]
     public function __doRequest($request, $location, $action, $version, $one_way = 0) : ?string
     {
         $userAgent = $this->getUserAgent();
@@ -313,6 +314,7 @@ class Client extends \SoapClient
 	/**
 	 * {@inheritDoc}
 	 */
+    #[ReturnTypeWillChange]
 	public function __setCookie( $name, $value = null ) : void
 	{
 		$this->cookies[ $name ] = $value;
@@ -605,7 +607,7 @@ class Client extends \SoapClient
      */
     private function hasProxyConfigured()
     {
-        return (strlen($this->proxyHost) > 0);
+        return ($this->proxyHost !== '');
     }
 
     /**


### PR DESCRIPTION
### Problema 📝

Se han identificado y abordado los warnings de soporte para PHP 8.1 en el código actual.

### Ticket(s) Relacionado(s) 🎫

- No aplica

### Cambios Realizados 🛠️

- Se han eliminado los warnings de soporte para PHP 8.1 en el código, asegurando así la compatibilidad y estabilidad del sistema.